### PR TITLE
feat: Bufferize operator #4

### DIFF
--- a/src/Bufferize.ts
+++ b/src/Bufferize.ts
@@ -1,0 +1,73 @@
+import { Fifo } from "./Fifo";
+import { Iter } from "./Iter";
+import { Operator } from "./Operator";
+
+export interface BufferizeOptions<T, R> {
+    getInitialValue: () => R;
+    getNextInitialValue?: (acc: R) => R;
+    reducer: (acc: R, value: T) => R;
+    shouldFlush?: (acc: R, value: T, bufferizedItemsCount: number) => boolean;
+    timeFrame?: number;
+}
+
+export function bufferize<T, R>({
+    getInitialValue,
+    getNextInitialValue = getInitialValue,
+    reducer,
+    shouldFlush = () => false,
+    timeFrame,
+}: BufferizeOptions<T, R>): Operator<T, R> {
+    return async function* bufferizeOperator(input: Iter<T>): Iter<R> {
+        const outputQueue = new Fifo<R>({
+            highWatermark: 1,
+        });
+
+        let acc: R = getInitialValue();
+        let count = 0;
+        let timeout: NodeJS.Timeout | null = null;
+
+        function cancelTimeframedFlush() {
+            if (timeout) {
+                clearTimeout(timeout);
+                timeout = null;
+            }
+        }
+
+        function scheduleTimeframedFlush() {
+            if (timeFrame && !timeout) {
+                timeout = setTimeout(async () => {
+                    await flushAcc();
+                }, timeFrame);
+            }
+        }
+
+        async function flushAcc() {
+            const result = acc;
+            acc = getNextInitialValue(acc);
+            count = 0;
+            await outputQueue.waitDrain();
+            cancelTimeframedFlush();
+            outputQueue.push(result);
+        }
+
+        async function readInput() {
+            for await (const value of input) {
+                scheduleTimeframedFlush();
+                acc = reducer(acc, value);
+                count++;
+
+                if (shouldFlush(acc, value, count)) {
+                    await flushAcc();
+                }
+            }
+            if (count > 0) {
+                await flushAcc();
+            }
+            outputQueue.end();
+        }
+
+        readInput();
+
+        yield* outputQueue;
+    };
+}

--- a/src/Chain.ts
+++ b/src/Chain.ts
@@ -1,4 +1,4 @@
-import { batch } from "./Batch";
+import { batch, BatchOptions } from "./Batch";
 import { concurrentMap, ConcurrentMapOptions } from "./ConcurrentMap";
 import { filter } from "./Filter";
 import { flatten } from "./Flatten";
@@ -6,9 +6,11 @@ import { interval } from "./Interval";
 import { Iter } from "./Iter";
 import { map } from "./Map";
 import { Operator } from "./Operator";
+import { bufferize, BufferizeOptions } from "./Bufferize";
 import { skip } from "./Skip";
 import { take } from "./Take";
 import { tap } from "./Tap";
+import { onEnd } from "./OnEnd";
 
 class Chain<I> implements AsyncIterable<I> {
     constructor(private source: Iter<I>) {}
@@ -101,8 +103,8 @@ class Chain<I> implements AsyncIterable<I> {
      * Once the iteration is stopped, the rest of the items will be returned
      * as a batch of possibly smaller size.
      */
-    batch(batchSize: number) {
-        return this.pipe(batch(batchSize));
+    batch(options: number | BatchOptions): Chain<I[]> {
+        return this.pipe(batch(options));
     }
 
     /**
@@ -148,6 +150,17 @@ class Chain<I> implements AsyncIterable<I> {
 
     skip(size: number): Chain<I> {
         return this.pipe(skip(size));
+    }
+
+    bufferize<O>(options: BufferizeOptions<I, O>): Chain<O> {
+        return this.pipe(bufferize(options));
+    }
+
+    /**
+     * Called once, when the iteration is done
+     */
+    onEnd(cb: () => void): Chain<I> {
+        return this.pipe(onEnd(cb));
     }
 }
 

--- a/src/Fifo.ts
+++ b/src/Fifo.ts
@@ -1,3 +1,5 @@
+import { sleep } from "./tests/sleep";
+
 export interface FifoOptions {
     highWatermark?: number;
     onSizeChange?: (size: number) => void;
@@ -89,7 +91,7 @@ export class Fifo<T> implements AsyncIterable<T> {
     }
     waitDrain(): Promise<void> {
         if (this.#isDrain()) {
-            return Promise.resolve();
+            return sleep(0);
         }
 
         const onDrainPromise =

--- a/src/Interval.ts
+++ b/src/Interval.ts
@@ -1,27 +1,17 @@
-import { Iter } from "./Iter";
+import { bufferize } from "./Bufferize";
 import { Operator } from "./Operator";
 
 export function interval<T>(size: number): Operator<T, [T, T]> {
-    return async function* intervalOperator(input: Iter<T>): Iter<[T, T]> {
-        let currentInterval: [T, T] | null = null;
-        let currentLength = 0;
-
-        for await (const value of input) {
-            if (currentInterval === null) {
-                currentInterval = [value, value];
-            } else {
-                currentInterval[1] = value;
+    return bufferize({
+        getInitialValue: (): [T, T] | null => null,
+        reducer(acc, value): [T, T] {
+            if (acc === null) {
+                return [value, value];
             }
-            currentLength++;
-
-            if (currentLength === size) {
-                yield currentInterval;
-                currentInterval = null;
-                currentLength = 0;
-            }
-        }
-        if (currentLength > 0 && currentInterval !== null) {
-            yield currentInterval;
-        }
-    };
+            acc[1] = value;
+            return acc;
+        },
+        shouldFlush: (_, __, bufferizedItemsCount) =>
+            bufferizedItemsCount >= size,
+    }) as Operator<T, [T, T]>;
 }

--- a/src/OnEnd.ts
+++ b/src/OnEnd.ts
@@ -1,0 +1,11 @@
+import { type Iter } from "./Iter";
+import { type Operator } from "./Operator";
+
+export function onEnd<T>(cb: () => void): Operator<T, T> {
+    return async function* onEndOperator(input: Iter<T>): Iter<T> {
+        for await (const v of input) {
+            yield v;
+        }
+        cb();
+    };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,3 +13,5 @@ export * from "./Skip";
 export * from "./Take";
 export * from "./Tap";
 export * from "./Interval";
+export * from "./Bufferize";
+export * from "./OnEnd";

--- a/src/tests/batch.spec.ts
+++ b/src/tests/batch.spec.ts
@@ -1,11 +1,46 @@
 import { chain } from "../Chain";
+import { range } from "../Range";
+import { sleep } from "./sleep";
 
 describe("chain.batch", () => {
     it("groups items into batches", async () => {
-        const result = await chain([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
-            .batch(3)
+        const result = await chain(range(0, 10)).batch(3).toArray();
+
+        expect(result).toEqual([[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]]);
+    });
+
+    it("groups items into batches, based on a time frame", async () => {
+        const result = await chain(range(0, 10))
+            .tap(() => sleep(10))
+            .batch({
+                timeFrame: 25,
+            })
             .toArray();
 
-        expect(result).toEqual([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10]]);
+        expect(result).toEqual([[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]]);
+    });
+
+    it("groups items into batches, based on a size or a time frame (size takes precedence)", async () => {
+        const result = await chain(range(0, 10))
+            .tap(() => sleep(10))
+            .batch({
+                timeFrame: 50,
+                size: 2,
+            })
+            .toArray();
+
+        expect(result).toEqual([
+            [0, 1],
+            [2, 3],
+            [4, 5],
+            [6, 7],
+            [8, 9],
+        ]);
+    });
+
+    it("groups items into a single batch if the size is Infinity", async () => {
+        const result = await chain(range(0, 10)).batch(Infinity).toArray();
+
+        expect(result).toEqual([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]]);
     });
 });

--- a/src/tests/bufferize.spec.ts
+++ b/src/tests/bufferize.spec.ts
@@ -1,0 +1,140 @@
+/* eslint-disable indent */
+import { chain } from "../Chain";
+import { range } from "../Range";
+import { sleep } from "./sleep";
+
+describe("Bufferize", () => {
+    it("can be used as batcher", async () => {
+        const bufferized = await chain(range(0, 10))
+            .bufferize({
+                getInitialValue: (): number[] => [],
+                reducer(acc, value) {
+                    acc.push(value);
+                    return acc;
+                },
+                shouldFlush(acc) {
+                    return acc.length >= 3;
+                },
+            })
+            .toArray();
+
+        expect(bufferized).toEqual([[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]]);
+    });
+
+    it("can be used as a timeframe-based batcher", async () => {
+        // Let's produce a new timestamp every 10 ms
+        const bufferized = await chain(range(0, 100))
+            .tap(() => sleep(10))
+            .map(() => Date.now())
+            // Let's pack into the batches at most every 210 ms
+            .bufferize({
+                timeFrame: 210,
+                getInitialValue: (): number[] => [],
+                reducer(acc, value) {
+                    acc.push(value);
+                    return acc;
+                },
+            })
+            .toArray();
+
+        // We should have 5 batches
+        expect(bufferized).toHaveLength(5);
+
+        // And the difference between the first and the last item in such a batch...
+        const realTimeFrames = bufferized.map(
+            (values) => values.at(-1)! - values.at(0)!,
+        );
+
+        // ...should be at most 220 ms
+        expect(realTimeFrames.every((timeFrame) => timeFrame <= 220)).toBe(
+            true,
+        );
+    });
+
+    it("can be used as sum calculator", async () => {
+        const sums = await chain(range(0, 10))
+            .bufferize({
+                getInitialValue: (): number => 0,
+                reducer(acc, value) {
+                    return acc + value;
+                },
+            })
+            .toArray();
+
+        expect(sums).toEqual([45]);
+    });
+
+    it("can be used as an actions reducer", async () => {
+        interface IncFoo {
+            type: "incFoo";
+            value: number;
+        }
+
+        interface IncBar {
+            type: "incBar";
+            value: number;
+        }
+
+        const actions: (IncFoo | IncBar)[] = [
+            { type: "incFoo", value: 1 },
+            { type: "incFoo", value: 1 },
+            { type: "incBar", value: -1 },
+            { type: "incBar", value: -1 },
+        ];
+
+        const stateSnapshots = await chain(actions)
+            .bufferize({
+                getInitialValue: () => ({ foo: 0, bar: 0 }),
+                shouldFlush: () => true,
+                // We do not want to loose the accumulated state
+                getNextInitialValue: (acc) => acc,
+                reducer(acc, action) {
+                    switch (action.type) {
+                        case "incFoo":
+                            return {
+                                ...acc,
+                                foo: acc.foo + action.value,
+                            };
+
+                        case "incBar":
+                            return {
+                                ...acc,
+                                bar: acc.bar + action.value,
+                            };
+                    }
+                },
+            })
+            .toArray();
+
+        expect(stateSnapshots).toEqual([
+            { foo: 1, bar: 0 },
+            { foo: 2, bar: 0 },
+            { foo: 2, bar: -1 },
+            { foo: 2, bar: -2 },
+        ]);
+    });
+
+    it("can be used as a non-standard batcher, packing numbers into batches when their sum exceeds a threshold", async () => {
+        interface BatchWithSum {
+            sum: number;
+            values: number[];
+        }
+
+        const batches = await chain(range(0, 10))
+            .bufferize({
+                getInitialValue: (): BatchWithSum => ({ sum: 0, values: [] }),
+                reducer(acc, value) {
+                    acc.values.push(value);
+                    acc.sum += value;
+                    return acc;
+                },
+                shouldFlush(acc) {
+                    return acc.sum >= 10;
+                },
+            })
+            .map((batch) => batch.values)
+            .toArray();
+
+        expect(batches).toEqual([[0, 1, 2, 3, 4], [5, 6], [7, 8], [9]]);
+    });
+});

--- a/src/tests/interval.spec.ts
+++ b/src/tests/interval.spec.ts
@@ -34,4 +34,20 @@ describe("chain.interval", () => {
             [9, 9],
         ]);
     });
+
+    it("groups items into intervals, even if the size of the interval is 0", async () => {
+        const result = await chain(range(0, 10)).interval(0).toArray();
+        expect(result).toEqual([
+            [0, 0],
+            [1, 1],
+            [2, 2],
+            [3, 3],
+            [4, 4],
+            [5, 5],
+            [6, 6],
+            [7, 7],
+            [8, 8],
+            [9, 9],
+        ]);
+    });
 });

--- a/src/tests/onEnd.spec.ts
+++ b/src/tests/onEnd.spec.ts
@@ -1,0 +1,19 @@
+import { chain } from "../Chain";
+import { range } from "../Range";
+
+describe("chain.teardown", () => {
+    it("calls a function on teardown", async () => {
+        const onTap = jest.fn();
+        const onEnd = jest.fn();
+
+        const result = await chain(range(0, 10))
+            .tap(onTap)
+            .onEnd(onEnd)
+            .toArray();
+
+        expect(result).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+        expect(onTap).toHaveBeenCalledTimes(10);
+        expect(onEnd).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/tests/sleep.ts
+++ b/src/tests/sleep.ts
@@ -1,3 +1,3 @@
-export function sleep(ms: number) {
+export function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
 - #4

- `bufferize` operator allows to build custom reducers, batchers etc. It can group items on different criteria or on timeframe base
- `onEnd` operator allows to call an arbitrary callback when the chain iteration ends
- `batch` now supports a new `timeFrame` option, allowing to use it as a timeframe batcher